### PR TITLE
44 timestamp conversion fail after switching to new api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -608,12 +608,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -632,16 +632,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.63",
+ "strsim 0.11.1",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -657,13 +657,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.9",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "dfir-toolkit"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -756,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc96511560e4661da0ada6debede9ed1dc63d8ac2ad8cefc00434e351a8b509"
 dependencies = [
  "anyhow",
- "darling 0.20.8",
+ "darling 0.20.9",
  "evtx",
  "log",
  "quote",
@@ -770,11 +770,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37be4820fae21cbed1f691dffcb02969b673bfeef4bd3fdee8cb175d1ca27023"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.9",
  "dfirtk-eventdata",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -830,9 +830,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elasticsearch"
@@ -1115,7 +1115,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1474,7 +1474,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1485,15 +1485,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lnk"
@@ -1687,7 +1687,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2050,7 +2050,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -2366,7 +2366,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2543,7 +2543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2559,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2685,7 +2685,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2958,7 +2958,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
  "wasm-bindgen-shared",
 ]
 
@@ -2992,7 +2992,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3317,7 +3317,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]

--- a/src/bin/mactime2/application.rs
+++ b/src/bin/mactime2/application.rs
@@ -40,7 +40,6 @@ pub (crate) enum OutputFormat {
 pub struct Mactime2Application {
     format: OutputFormat,
     bodyfile: Input,
-    src_zone: Tz,
     dst_zone: Tz,
     strict_mode: bool,
 }
@@ -52,7 +51,6 @@ impl Mactime2Application {
     ) -> Box<dyn Sorter<Result<(), MactimeError>>> {
         let options = RunOptions {
             strict_mode: self.strict_mode,
-            src_zone: self.src_zone,
         };
 
         if matches!(self.format, OutputFormat::Json) {
@@ -62,8 +60,8 @@ impl Mactime2Application {
                 BodyfileSorter::default().with_receiver(decoder.get_receiver(), options);
 
             sorter = sorter.with_output(match self.format {
-                OutputFormat::Csv => Box::new(CsvOutput::new(self.src_zone, self.dst_zone)),
-                OutputFormat::Txt => Box::new(TxtOutput::new(self.src_zone, self.dst_zone)),
+                OutputFormat::Csv => Box::new(CsvOutput::new(self.dst_zone)),
+                OutputFormat::Txt => Box::new(TxtOutput::new(self.dst_zone)),
                 _ => panic!("invalid execution path"),
             });
             Box::new(sorter)
@@ -73,7 +71,6 @@ impl Mactime2Application {
     pub fn run(&self) -> anyhow::Result<()> {
         let options = RunOptions {
             strict_mode: self.strict_mode,
-            src_zone: self.src_zone,
         };
 
         let mut reader = <BodyfileReader as StreamReader<String, ()>>::from(self.bodyfile.clone())?;
@@ -106,7 +103,6 @@ impl From<Cli> for Mactime2Application {
         Self {
             format,
             bodyfile: cli.input_file,
-            src_zone: cli.src_zone.into_tz().unwrap(),
             dst_zone: cli.dst_zone.into_tz().unwrap(),
             strict_mode: cli.strict_mode,
         }

--- a/src/bin/mactime2/cli.rs
+++ b/src/bin/mactime2/cli.rs
@@ -40,10 +40,6 @@ pub struct Cli {
     #[clap(short('j'), display_order(620))]
     pub(crate) json_format: bool,
 
-    /// name of offset of source timezone (or 'list' to display all possible values
-    #[clap(short('f'), long("from-timezone"), display_order(300), default_value_t=TzArgument::Tz(Tz::UTC))]
-    pub src_zone: TzArgument,
-
     /// name of offset of destination timezone (or 'list' to display all possible values
     #[clap(short('t'), long("to-timezone"), display_order(400), default_value_t=TzArgument::Tz(Tz::UTC))]
     pub dst_zone: TzArgument,

--- a/src/bin/mactime2/cli.rs
+++ b/src/bin/mactime2/cli.rs
@@ -13,9 +13,17 @@ const BODYFILE_HELP: &str =
 #[cfg(not(feature = "gzip"))]
 const BODYFILE_HELP: &str = "path to input file or '-' for stdin";
 
-/// replacement for `mactime`
+/// Replacement for `mactime`
 #[derive(Parser)]
-#[clap(name="mactime2", author, version, long_about = None)]
+#[clap(name="mactime2", author, version, long_about = None, after_help=
+r##"
+╭────────────────────────────────────────────────────────────────────────────╮
+│IMPORTANT:                                                                  │
+│                                                                            │
+│Note that POSIX specifies that all UNIX timestamps are UTC timestamps. It is│
+│up to you to ensure that the bodyfile only contains UNIX timestamps that    │
+│comply with the POSIX standard.                                             │
+╰────────────────────────────────────────────────────────────────────────────╯"##)]
 
 pub struct Cli {
     #[clap(short('b'), value_parser, value_hint=ValueHint::FilePath, default_value="-", help=BODYFILE_HELP, display_order(100))]

--- a/src/bin/mactime2/filter.rs
+++ b/src/bin/mactime2/filter.rs
@@ -1,11 +1,8 @@
 use std::sync::mpsc::{Sender, Receiver};
 
-use chrono_tz::Tz;
-
 #[derive(Copy, Clone)]
 pub struct RunOptions {
     pub strict_mode: bool,
-    pub src_zone: Tz
 }
 
 pub trait Provider<To, R>: Joinable<R> {

--- a/src/bin/mactime2/main.rs
+++ b/src/bin/mactime2/main.rs
@@ -15,12 +15,11 @@ use dfir_toolkit::common::{FancyParser, TzArgument};
 fn main() -> Result<()> {
     let cli: Cli = Cli::parse_cli();
 
-    if cli.src_zone.is_list() || cli.dst_zone.is_list() {
+    if cli.dst_zone.is_list() {
         TzArgument::display_zones();
         return Ok(());
     }
     debug_assert!(cli.dst_zone.is_tz());
-    debug_assert!(cli.src_zone.is_tz());
 
     let app: Mactime2Application = cli.into();
 

--- a/src/bin/mactime2/output/csv_output.rs
+++ b/src/bin/mactime2/output/csv_output.rs
@@ -63,14 +63,12 @@ mod tests {
 
             let out_line = output.fmt(&unix_ts, &entry);
             let out_ts = out_line.split(',').next().unwrap();
-            let rfc3339 = DateTime::parse_from_rfc3339(out_ts).expect(out_ts);
+            let rfc3339 = DateTime::parse_from_rfc3339(out_ts)
+                .expect(out_ts)
+                .timestamp();
             assert_eq!(
-                unix_ts,
-                rfc3339.timestamp(),
-                "Timestamp {} converted to '{}' and back to {}",
-                unix_ts,
-                out_ts,
-                rfc3339.timestamp()
+                unix_ts, rfc3339,
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {rfc3339}",
             );
         }
     }
@@ -98,8 +96,7 @@ mod tests {
             let calculated_ts = rfc3339.timestamp() + offset;
             assert_eq!(
                 unix_ts, calculated_ts,
-                "Timestamp {} converted to '{}' and back to {} (offset was {}s)",
-                unix_ts, out_ts, calculated_ts, offset
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts} (offset was {offset}s)",
             );
         }
         Ok(())

--- a/src/bin/mactime2/output/csv_output.rs
+++ b/src/bin/mactime2/output/csv_output.rs
@@ -4,19 +4,18 @@ use dfir_toolkit::common::ForensicsTimestamp;
 use crate::bodyfile::{ListEntry, Mactime2Writer};
 
 pub(crate) struct CsvOutput {
-    src_zone: Tz,
     dst_zone: Tz,
 }
 
 impl CsvOutput {
-    pub fn new(src_zone: Tz, dst_zone: Tz) -> Self {
-        Self { src_zone, dst_zone }
+    pub fn new(dst_zone: Tz) -> Self {
+        Self { dst_zone }
     }
 }
 
 impl Mactime2Writer for CsvOutput {
     fn fmt(&self, timestamp: &i64, entry: &ListEntry) -> String {
-        let timestamp = ForensicsTimestamp::new(*timestamp, self.src_zone, self.dst_zone);
+        let timestamp = ForensicsTimestamp::from(*timestamp).with_timezone(self.dst_zone);
         format!(
             "{},{},{},{},{},{},{},\"{}\"",
             timestamp,
@@ -52,7 +51,7 @@ mod tests {
     #[allow(non_snake_case)]
     #[test]
     fn test_correct_ts_UTC() {
-        let output = CsvOutput::new(Tz::UTC, Tz::UTC);
+        let output = CsvOutput::new(Tz::UTC);
         for _ in 1..10 {
             let unix_ts = rand::random::<u32>() as i64;
             let bf_line = Bodyfile3Line::new().with_crtime(unix_ts.into());
@@ -78,7 +77,7 @@ mod tests {
     fn test_correct_ts_random_tz() -> Result<(), String> {
         for _ in 1..100 {
             let tz = random_tz();
-            let output = CsvOutput::new(tz, tz);
+            let output = CsvOutput::new(tz);
             let unix_ts = rand::random::<u32>() as i64;
             let bf_line = Bodyfile3Line::new().with_crtime(unix_ts.into());
             let entry = ListEntry {

--- a/src/bin/mactime2/output/csv_output.rs
+++ b/src/bin/mactime2/output/csv_output.rs
@@ -91,11 +91,10 @@ mod tests {
                 Ok(ts) => ts,
                 Err(e) => return Err(format!("error while parsing '{}': {}", out_ts, e)),
             };
-            let offset = rfc3339.offset().local_minus_utc() as i64;
-            let calculated_ts = rfc3339.timestamp() + offset;
+            let calculated_ts = rfc3339.timestamp();
             assert_eq!(
                 unix_ts, calculated_ts,
-                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts} (offset was {offset}s)",
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts}",
             );
         }
         Ok(())

--- a/src/bin/mactime2/output/txt_output.rs
+++ b/src/bin/mactime2/output/txt_output.rs
@@ -79,14 +79,12 @@ mod tests {
             assert!(out_line2.starts_with(' '));
 
             let out_ts = out_line.split(' ').next().unwrap();
-            let rfc3339 = DateTime::parse_from_rfc3339(out_ts).expect(out_ts);
+            let rfc3339 = DateTime::parse_from_rfc3339(out_ts)
+                .expect(out_ts)
+                .timestamp();
             assert_eq!(
-                unix_ts,
-                rfc3339.timestamp(),
-                "Timestamp {} converted to '{}' and back to {}",
-                unix_ts,
-                out_ts,
-                rfc3339.timestamp()
+                unix_ts, rfc3339,
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {rfc3339}",
             );
         }
     }
@@ -117,8 +115,7 @@ mod tests {
             let calculated_ts = rfc3339.timestamp() + offset;
             assert_eq!(
                 unix_ts, calculated_ts,
-                "Timestamp {} converted to '{}' and back to {} (offset was {}s)",
-                unix_ts, out_ts, calculated_ts, offset
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts} (offset was {offset}s)",
             );
         }
         Ok(())

--- a/src/bin/mactime2/output/txt_output.rs
+++ b/src/bin/mactime2/output/txt_output.rs
@@ -110,11 +110,10 @@ mod tests {
                 Ok(ts) => ts,
                 Err(e) => return Err(format!("error while parsing '{}': {}", out_ts, e)),
             };
-            let offset = rfc3339.offset().local_minus_utc() as i64;
-            let calculated_ts = rfc3339.timestamp() + offset;
+            let calculated_ts = rfc3339.timestamp();
             assert_eq!(
                 unix_ts, calculated_ts,
-                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts} (offset was {offset}s)",
+                "Timestamp {unix_ts} converted to '{out_ts}' and back to {calculated_ts}",
             );
         }
         Ok(())

--- a/src/bin/ts2date/main.rs
+++ b/src/bin/ts2date/main.rs
@@ -28,8 +28,7 @@ fn main() -> Result<()> {
 
         let out = match re.captures(&content) {
             Some(caps) => {
-                //let ndt = NaiveDateTime::from_timestamp_opt(caps.name("ts").unwrap().as_str().parse::<i64>().unwrap(),0).unwrap();
-                let ts = ForensicsTimestamp::new(caps.name("ts").unwrap().as_str().parse::<i64>().unwrap(),cli.src_zone.into_tz().unwrap(), cli.dst_zone.into_tz().unwrap());
+                let ts = ForensicsTimestamp::from(caps.name("ts").unwrap().as_str().parse::<i64>().unwrap()).with_timezone(cli.dst_zone.into_tz().unwrap());
                 format!("{}{}{}", caps.name("lhs").unwrap().as_str(),
                                             ts,
                                             caps.name("rhs").unwrap().as_str())

--- a/src/common/bodyfile/bodyfile3.rs
+++ b/src/common/bodyfile/bodyfile3.rs
@@ -75,7 +75,7 @@ impl Bodyfile3Line {
         [with_mode]   [mode_as_string];
     )]
     pub fn method_name(mut self, attribute_name: &str) -> Self {
-        self.attribute_name = attribute_name.to_owned();
+        attribute_name.clone_into(&mut self.attribute_name);
         self
     }
 

--- a/src/common/forensics_timestamp.rs
+++ b/src/common/forensics_timestamp.rs
@@ -66,7 +66,7 @@ impl ForensicsTimestamp {
 impl Display for ForensicsTimestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.unix_ts >= 0 {
-            let src_timestamp = match DateTime::from_timestamp(1715845546, 0) {
+            let src_timestamp = match DateTime::from_timestamp(self.unix_ts, 0) {
                 Some(ts) => ts,
                 None => panic!("unable to convert '{}' into unix timestamp", self.unix_ts),
             }

--- a/src/es4forensics/ecs/objects/posix_file.rs
+++ b/src/es4forensics/ecs/objects/posix_file.rs
@@ -86,13 +86,6 @@ impl IntoIterator for PosixFile {
     }
 }
 
-impl TryFrom<(Bodyfile3Line, &Tz)> for PosixFile {
-    type Error = anyhow::Error;
-    fn try_from((bfline, src_tz): (Bodyfile3Line, &Tz)) -> Result<Self> {
-        Self::try_from((&bfline, src_tz))
-    }
-}
-
 impl TryFrom<Bodyfile3Line> for PosixFile {
     type Error = anyhow::Error;
     fn try_from(bfline: Bodyfile3Line) -> Result<Self> {

--- a/tests/ts2date.rs
+++ b/tests/ts2date.rs
@@ -49,29 +49,6 @@ fn ts2date_utc2berlin() {
     );
 }
 
-#[test]
-fn ts2date_berlin2utc() {
-    const SAMPLE_TIMELINE_OUT: &str = r#"2023-08-30T14:08:37+00:00|REG|||App Paths - protocolhandler.exe - C:\Program Files\WindowsApps\Microsoft.Office.Desktop_16051.16626.20170.0_x86__8wekyb3d8bbwe\Office16\protocolhandler.exe
-2023-08-30T14:08:37+00:00|REG|||App Paths - sdxhelper.exe - C:\Program Files\WindowsApps\Microsoft.Office.Desktop_16051.16626.20170.0_x86__8wekyb3d8bbwe\Office16\SDXHelper.exe
-2023-08-30T14:08:37+00:00|REG|||App Paths - selfcert.exe - C:\Program Files\WindowsApps\Microsoft.Office.Desktop_16051.16626.20170.0_x86__8wekyb3d8bbwe\Office16\SELFCERT.exe
-2023-08-30T14:06:21+00:00|REG|||App Paths - msaccess.exe - C:\Program Files\WindowsApps\Microsoft.Office.Desktop.Access_16051.16626.20170.0_x86__8wekyb3d8bbwe\Office16\MSACCESS.exe
-"#;
-
-    let mut cmd = Command::cargo_bin("ts2date").unwrap();
-    let result = cmd
-        .arg("-f")
-        .arg("Europe/Berlin")
-        .arg("-t")
-        .arg("UTC")
-        .write_stdin(SAMPLE_TIMELINE)
-        .ok();
-    assert!(result.is_ok());
-
-    assert_eq!(
-        SAMPLE_TIMELINE_OUT,
-        String::from_utf8(result.unwrap().stdout).unwrap()
-    );
-}
 
 #[test]
 fn ts2date_list1() {


### PR DESCRIPTION
fixes #44.

The problem was that version *0.4.35* of chronotope/chrono removes all methods that allow to import a timestamp from another timezone than UTC (https://github.com/chronotope/chrono/releases/tag/v0.4.35):

> We deprecated all timestamp-related methods on `NaiveDateTime`. The reason is that a timestamp is defined to be in UTC. The `NaiveDateTime` type doesn't know the offset from UTC, so it was technically wrong to have these methods. The alternative is to use the similar methods on the `DateTime<Utc>` type, or from the `TimeZone` trait.

So, this functionality has also been removed from dfir-toolkit and -- especially -- from mactime2.