### PR TITLE
Fix missing dependancy in installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 # Installation
 
 ```bash
-sudo apt install libscca-dev
+sudo apt install libscca-dev libssl-dev
 cargo install dfir-toolkit
 ```
 


### PR DESCRIPTION
If libssl-dev is not installed, following error will be raised when doing cargo install 

```
  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags openssl

  The system library `openssl` required by crate `openssl-sys` was not found.
  The file `openssl.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `openssl.pc`.


  --- stderr
  thread 'main' panicked at /home/vprb6956/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-sys-0.9.103/build/find_normal.rs:190:5:


  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.103
``